### PR TITLE
Offsetcals adc1 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ void setStartPin(uint8_t pin)
 Optional. Designate an Arduino pin to start ADC1.
 If not used, a command will be sent instead.
 
+void setDrdyPin(uint8_t pin)
+-----------------------------
+Optional. Designate an Arduino pin to watch for Data Ready.
+If not used, calibrations will require a `waitTime` and dataReady() will always return true.
 
 General Commands
 ================
@@ -122,60 +126,62 @@ void reset()
 ------------
 Resets the chip.
 
-void startADC1()
+void startADC1(uint8_t pos_pin, uint8_t neg_pin)
 ----------------
-Starts conversion on ADC1.
+Starts conversion on ADC1 between the two pins `pos_pin` and `neg_pin`.
+These can be:
+
+|        Option         | Description                                    |
+|-----------------------|------------------------------------------------|
+| `0` or `ADS126X_AIN0` | Pin AIN0                                       |
+|          ...          |    ...                                         |
+| `9` or `ADS126X_AIN9` | Pin AIN9                                       |
+|   `ADS126X_AINCOM`    | Pin AINCOM                                     |
+|     `ADS126X_TEMP`    | Temperature sensor monitor positive/negative   |
+|    `ADS126X_ANALOG`   | Analog power supply monitor positive/negative  |
+|   `ADS126X_DIGITAL`   | Digital power supply monitor positive/negative |
+|     `ADS126X_TDAC`    | TDAC test signal positive/negative             |
+|    `ADS126X_FLOAT`    | Float (open connection)                        |
 
 void stopADC1()
 ---------------
-Stops conversion on ADC1.
+Stops conversion on ADC1. Uses `start_pin` if it was set (via `setStartPin`), sends a command if it wasn't.
 
-void startADC2()
+void startADC2(uint8_t pos_pin, uint8_t neg_pin)
 ----------------
-Starts conversion on ADC2.  
+Starts conversion on ADC2 between the two pins `pos_pin` and `neg_pin`.
+These can be:
+
+|        Option         | Description                                    |
+|-----------------------|------------------------------------------------|
+| `0` or `ADS126X_AIN0` | Pin AIN0                                       |
+|          ...          |    ...                                         |
+| `9` or `ADS126X_AIN9` | Pin AIN9                                       |
+|   `ADS126X_AINCOM`    | Pin AINCOM                                     |
+|     `ADS126X_TEMP`    | Temperature sensor monitor positive/negative   |
+|    `ADS126X_ANALOG`   | Analog power supply monitor positive/negative  |
+|   `ADS126X_DIGITAL`   | Digital power supply monitor positive/negative |
+|     `ADS126X_TDAC`    | TDAC test signal positive/negative             |
+|    `ADS126X_FLOAT`    | Float (open connection)                        |  
 
 void stopADC2()
 ---------------
 Stops conversion on ADC2.  
 
-
 Analog Read Functions
 =====================
 
-int32_t readADC1(uint8_t pos_pin,uint8_t neg_pin)
+int32_t readADC1()
 -------------------------------------------------
-Reads the 32 bit voltage between the two pins `pos_pin` and `neg_pin`.
-These can be:
-
-|        Option         | Description                                    |
-|-----------------------|------------------------------------------------|
-| `0` or `ADS126X_AIN0` | Pin AIN0                                       |
-|          ...          |    ...                                         |
-| `9` or `ADS126X_AIN9` | Pin AIN9                                       |
-|   `ADS126X_AINCOM`    | Pin AINCOM                                     |
-|     `ADS126X_TEMP`    | Temperature sensor monitor positive/negative   |
-|    `ADS126X_ANALOG`   | Analog power supply monitor positive/negative  |
-|   `ADS126X_DIGITAL`   | Digital power supply monitor positive/negative |
-|     `ADS126X_TDAC`    | TDAC test signal positive/negative             |
-|    `ADS126X_FLOAT`    | Float (open connection)                        |
+Reads the 32 bit voltage between the pins set in `startADC1`.
 
 int32_t readADC2(uint8_t pos_pin,uint8_t neg_pin)
 -------------------------------------------------
-Reads the 24 bit voltage between the two pins `pos_pin` and `neg_pin`.
-These can be:
+Reads the 24 bit voltage between the pins set in `startADC2`.
 
-|        Option         | Description                                    |
-|-----------------------|------------------------------------------------|
-| `0` or `ADS126X_AIN0` | Pin AIN0                                       |
-|          ...          |    ...                                         |
-| `9` or `ADS126X_AIN9` | Pin AIN9                                       |
-|   `ADS126X_AINCOM`    | Pin AINCOM                                     |
-|     `ADS126X_TEMP`    | Temperature sensor monitor positive/negative   |
-|    `ADS126X_ANALOG`   | Analog power supply monitor positive/negative  |
-|   `ADS126X_DIGITAL`   | Digital power supply monitor positive/negative |
-|     `ADS126X_TDAC`    | TDAC test signal positive/negative             |
-|    `ADS126X_FLOAT`    | Float (open connection)                        |
-
+bool dataReady()
+---------------
+If `setDrdyPin` was used, returns true when the adc's `DRDY` (data ready indicator) pin is `LOW`. If not pin was set, this always returns true. Useful for getting continuous conversions as quickly as possible. Almost certainly faster than command polling (especially if you attach this pin to an interrupt routine).
 
 Calibration Functions
 =====================
@@ -552,6 +558,10 @@ Selects the PGA gain
 | `ADS126X_GAIN_8`  | 8 V/V  |
 | `ADS126X_GAIN_16` | 16 V/V |
 | `ADS126X_GAIN_32` | 32 V/V |
+
+void getGain()
+--------------
+Returns the value of the constant used in setGain (i.e. `ADS126X_GAIN_1` -> `0b000` which is int `0`). To get the corresponding actual voltage gain, do something like `uint8_t voltageGainValue = 1 << adc.getGain();` (`ADS126X_GAIN_1` would return `1`).
 
 void setRate(uint8_t rate)
 --------------------------

--- a/examples/basics/basics.ino
+++ b/examples/basics/basics.ino
@@ -15,13 +15,13 @@ void setup() {
   Serial.begin(115200);
   
   adc.begin(chip_select); // setup with chip select pin
-  adc.startADC1(); // start conversion on ADC1
+  adc.startADC1(pos_pin, neg_pin); // start conversion on ADC1
   
   Serial.println("Reading Voltages:");
 }
 
 void loop() {
-  long voltage = adc.readADC1(pos_pin,neg_pin); // read the voltage
+  long voltage = adc.readADC1(); // read the voltage
   Serial.println(voltage); // send voltage through serial
   delay(1000); // wait 1 second
 }

--- a/src/ADS126X.h
+++ b/src/ADS126X.h
@@ -33,9 +33,9 @@ class ADS126X {
     int32_t readADC1(void);
     int32_t readADC2(void);
     // Calibration Functions
-    void calibrateSysOffsetADC1(uint8_t shorted1,uint8_t shorted2);
+    void calibrateSysOffsetADC1(uint8_t shorted1,uint8_t shorted2, uint16_t waitTime);
     void calibrateGainADC1(uint8_t vcc_pin,uint8_t gnd_pin);
-    void calibrateSelfOffsetADC1(void);
+    void calibrateSelfOffsetADC1(uint16_t waitTime);
     void calibrateSysOffsetADC2(uint8_t shorted1,uint8_t shorted2);
     void calibrateGainADC2(uint8_t vcc_pin,uint8_t gnd_pin);
     void calibrateSelfOffsetADC2(void);


### PR DESCRIPTION
My attempt to fix Molorius/ADS126X#18. Follows datasheet section 9.4.9.8 Calibration Command Procedure. 

NOTE: I didn't fix every cal procedure. This also depends on some changes from PR Molorius/ADS126X#21. 

- [x] fix `calibrateSysOffsetADC1(shorted1,shorted2,waitTime=0)`. (set continuous mode, then start shorted conversion BEFORE calibrating)
- [x] fix `calibrateSelfOffsetADC1(waitTime=0)`. (set continuous mode, then start floating conversion BEFORE calibrating)
- [x] waits for DRDY pin to be low OR for a specified wait time (table 9-28 in section 9.4.9.8, pg79). Max possible time is 9201 ms (2.5SPS + Sinc4)
  - user must determine their own wait time if not using DRDY. Just use DRDY if you can!
- [x] update README

Only tested with ADS1262. Seems to work well! Strangely, selfOffset gives me results that are further away from zero once the inputs are shorted but really stable - I suppose the extra resistance of my breakout? I'm using the mikroe click adc13. Maybe someone else can test and let me know if this is good? 